### PR TITLE
Fixing a bug with a number of threads for the forward loop.

### DIFF
--- a/roi_pooling.cu
+++ b/roi_pooling.cu
@@ -185,7 +185,6 @@ int APPLY_SPECIFIC(Forward_gpu)(CudaNdarray* data,
                                 CudaNdarray* rois,
                                 CudaNdarray** out,
                                 CudaNdarray** argmaxes) {
-  int count = CudaNdarray_SIZE(data);
   int batch_size = CudaNdarray_DIMS(rois)[0];
   int channels = CudaNdarray_DIMS(data)[1];
   int height = CudaNdarray_DIMS(data)[2];
@@ -197,6 +196,9 @@ int APPLY_SPECIFIC(Forward_gpu)(CudaNdarray* data,
   dims[1] = channels;
   dims[2] = POOLED_HEIGHT;
   dims[3] = POOLED_WIDTH;
+
+  int count = batch_size * channels * POOLED_HEIGHT * POOLED_WIDTH;
+
   CudaNdarray_prep_output(out, 4, dims);
   CudaNdarray_prep_output(argmaxes, 4, dims);
 


### PR DESCRIPTION
Hi Yaroslav,

Thank you for making effort to port RoI pooling to theano. There is a bug in your implementation. Number of threads in the forward pass should be equal to the size of an output tensor but not an input tensor.

Best Regards,

Minh
